### PR TITLE
[Feat/#6] 비밀번호 단방향 암호화 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
 		    <version>1.13.1</version>
 		</dependency>
 
+        <!--스프링 시큐리티(Spring Security) 사용을 위해 추가 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/mg/sw09/asig/config/SecurityConfig.java
+++ b/src/main/java/mg/sw09/asig/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package mg.sw09.asig.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    //암호화 모듈 등록
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    //보안 필터 설정
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable() //CSRF 보안 비활성화
+                .cors().disable()
+                .formLogin().disable() //기본 로그인 페이지 비활성화
+                .authorizeRequests()
+                .anyRequest().permitAll(); //모든 요청 허용
+
+        return http.build();
+    }
+}

--- a/src/main/java/mg/sw09/asig/controller/MemberController.java
+++ b/src/main/java/mg/sw09/asig/controller/MemberController.java
@@ -26,7 +26,7 @@ public class MemberController {
     private PointMapper pointMapper;
 
     @Autowired
-    private PasswordEncoder passwordEncoder;
+    private PasswordEncoder passwordEncoder; //비밀번호 해싱 기능 인터페이스
 
     @GetMapping("/jgig/register")
     public String toSignupPage() { // 회원가입 페이지
@@ -149,6 +149,10 @@ public class MemberController {
     public String toUpdatePage(MemberDto dto, HttpSession session, Model model) { // 회원 정보 수정 페이지
         String mem_id = (String) session.getAttribute("mem_id");
         MemberDto update_dto = memberMapper.detail(mem_id);
+
+        //비밀번호는 수정 페이지에 노출되지 않도록 수정
+        update_dto.setMem_pw("");
+
         model.addAttribute("memberDto", update_dto);
         return "member/update";
     }
@@ -157,6 +161,17 @@ public class MemberController {
     public String Update(MemberDto dto, HttpSession session, Model model) { // 회원 정보 수정
         String mem_id = (String) session.getAttribute("mem_id");
         dto.setMem_id(mem_id);
+
+        if (dto.getMem_pw() == null || dto.getMem_pw().trim().isEmpty()) {
+            //비밀번호 입력 X -> DB에서 기존 비밀번호 가져와서 설정 (비밀번호 유지)
+            MemberDto origin = memberMapper.detail(mem_id);
+            dto.setMem_pw(origin.getMem_pw());
+        } else {
+            //새 비밀번호 입력 -> 새 비밀번호 암호화 후, 설정
+            String encodedPw = passwordEncoder.encode(dto.getMem_pw());
+            dto.setMem_pw(encodedPw);
+        }
+
         memberMapper.update(dto);
         return "member/detail";
     }

--- a/src/main/java/mg/sw09/asig/controller/MemberController.java
+++ b/src/main/java/mg/sw09/asig/controller/MemberController.java
@@ -194,13 +194,14 @@ public class MemberController {
         if (mem_id != null) {
             String savedPassword = memberMapper.getPassword(mem_id);
 
-            if (savedPassword != null && savedPassword.equals(inputPassword)) {
-                // 비밀번호가 일치하는 경우 회원 탈퇴 처리
+            //passwordEncoder로 암호화된 비밀번호 비교하도록 수정
+            if (savedPassword != null && passwordEncoder.matches(inputPassword, savedPassword)) {
+                //비밀번호가 일치하는 경우 회원 탈퇴 처리
                 memberMapper.delete(mem_id);
                 session.invalidate();
                 return "redirect:/jgig/login";
             } else {
-                // 비밀번호가 일치하지 않는 경우 에러 메시지를 리다이렉트로 전달
+                //비밀번호가 일치하지 않는 경우 에러 메시지를 리다이렉트로 전달
                 session.setAttribute("error", "비밀번호가 일치하지 않습니다. 다시 입력해주세요.");
                 return "redirect:/jgig/member_delete"; // 비밀번호 다시 입력 페이지로 리다이렉트
                 }


### PR DESCRIPTION
## 🌟 기능 설명
Spring Security의 BCryptPasswordEncoder를 도입하여 비밀번호를 원본으로 되돌릴 수 없는 단방향 해시(Hash)
형태로 DB에 저장하도록 구현했습니다.

-  SecurityConfig 코드 구현
-  회원가입/로그인 시, 비밀번호 암호화 로직 구현
- 회원 정보 수정 시, 비밀번호 암호화 로직 구현
- 회원 삭제 시, 비밀번호 비교 로직 변경

<br>

## 🌟 테스트 성공 결과 스크린샷
<img width="678" height="180" alt="비번 해시 값으로 저장" src="https://github.com/user-attachments/assets/ff573de1-25d6-4ce3-9e62-b89b3cbdf017" />

<br>

## 🌟 연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #6
<br>
<br>

## 🌟 Approve 하기 전 확인해주세요!
- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
  <br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?